### PR TITLE
Update ChangeClass.cs

### DIFF
--- a/OrderbotTags/ChangeClass.cs
+++ b/OrderbotTags/ChangeClass.cs
@@ -101,7 +101,7 @@ namespace LlamaUtilities.OrderbotTags
                 }
             }
 
-            _isDone = true;
+            _isDone = Core.Me.CurrentJob == newjob;
         }
 
         protected override Composite CreateBehavior()


### PR DESCRIPTION
only set done to `true` if we actually changed jobs. This is because This script may trigger too quickly after interactions (say talking to an NPC). So we shouldn't say we are done until we have successfully changed jobs. 

This may result in being stuck trying to change jobs. TBD if that's worse than not chaining jobs.