### PR TITLE
Turn in up to 4000 purple scrips at a time.

### DIFF
--- a/OrderbotTags/LLTurnInCollectables.cs
+++ b/OrderbotTags/LLTurnInCollectables.cs
@@ -118,7 +118,7 @@ namespace LlamaUtilities.OrderbotTags
 
                     for (var i = 0; i < count; i++)
                     {
-                        if (CurrencyHelper.GetAmountOfCurrency(currency) + item.Reward > 2000)
+                        if (CurrencyHelper.GetAmountOfCurrency(currency) + item.Reward > 4000)
                         {
                             break;
                         }


### PR DESCRIPTION
Turn in up to 4000 purple scrips at a time. Slightly more efficient.